### PR TITLE
HOCS-5140: action failure slack integration

### DIFF
--- a/.github/workflows/semver-manual.yml
+++ b/.github/workflows/semver-manual.yml
@@ -17,7 +17,7 @@ jobs:
     name: Manual SemVer Tag
     runs-on: ubuntu-latest
     steps:
-      - uses: UKHomeOffice/semver-tag-action@v1
+      - uses: UKHomeOffice/semver-tag-action@v2
         with:
           increment: ${{ github.event.inputs.increment }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semver-manual.yml
+++ b/.github/workflows/semver-manual.yml
@@ -21,3 +21,13 @@ jobs:
         with:
           increment: ${{ github.event.inputs.increment }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_use_head_tag: true
+      - name: Post failure to Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.19.0
+        if: ${{ failure() && steps.*.conclusion == 'failure' }}
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "GitHub Action failure: ${{github.repository}}\nRun: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}\nOriginating PR: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -21,3 +21,12 @@ jobs:
           increment: ${{ steps.label.outputs.matchedLabels }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_use_head_tag: ${{ github.base_ref == 'main' }}
+      - name: Post failure to Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.19.0
+        if: ${{ failure() && steps.*.conclusion == 'failure' }}
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "GitHub Action failure: ${{github.repository}}\nRun: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}\nOriginating PR: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
When a GitHub job fails there is currently know way of identifying this,
this change sends a notification to a channel of our choosing to flag
that there is an issue that needs looking at.

To simplify upgrades to the action - this change pegs the version to the
latest major tag `v2` in this instance.