### PR TITLE
⬇️ Use 20.04 over 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:18-jre-jammy
+FROM eclipse-temurin:18-jre-focal
 
 RUN groupadd -r group_hocs && \
     useradd -r -u 10000 -g group_hocs user_hocs -d /app && \


### PR DESCRIPTION
Prod is using an older version of docker/containerd that doesn't support glibc in 22.04, use 20.04 until the cluster is upgraded