### PR TITLE
Fix import name typo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.13.11-jre-jammy
+FROM eclipse-temurin:17.0.13_11-jre-jammy
 
 RUN groupadd -r group_hocs && \
     useradd -r -u 10000 -g group_hocs user_hocs -d /app && \


### PR DESCRIPTION
[Anchore scan](https://github.com/UKHomeOffice/hocs-base-image/actions/runs/12690251621/job/35370701442?pr=89) is now enabled, so build has been run successfully in GH actions as part of that. Action was disabled due to lack of repo activity on previous PR which is why it wasn't caught before merge